### PR TITLE
Add credit utilisation calculator and testimonial snippet

### DIFF
--- a/components/CreditCheckCalculator.tsx
+++ b/components/CreditCheckCalculator.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+export default function CreditCheckCalculator() {
+  const [limit, setLimit] = useState(0);
+  const [balance, setBalance] = useState(0);
+
+  const utilisation = limit > 0 ? Math.round((balance / limit) * 100) : 0;
+  const status = utilisation < 30 ? "Excellent" : utilisation < 50 ? "Fair" : "Needs attention";
+
+  return (
+    <div className="glass-card glass-morph rounded-2xl p-4 sm:p-6">
+      <h3 className="font-semibold mb-2">Credit utilisation calculator</h3>
+      <div className="space-y-3">
+        <label className="block text-sm">
+          Total credit limit (£)
+          <input
+            type="number"
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value))}
+            className="mt-1 w-full rounded-xl border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </label>
+        <label className="block text-sm">
+          Current balance (£)
+          <input
+            type="number"
+            value={balance}
+            onChange={(e) => setBalance(Number(e.target.value))}
+            className="mt-1 w-full rounded-xl border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </label>
+        {limit > 0 && (
+          <div className="mt-2 text-sm">
+            <p>Utilisation: <span className="font-semibold">{utilisation}%</span></p>
+            <p>Rating: <span className="font-semibold">{status}</span></p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,7 @@ import {
   Award,
   Star,
 } from "lucide-react";
+import CreditCheckCalculator from "../components/CreditCheckCalculator";
 
 // ================================================
 // Credit Cleaners — Lead Gen Landing (UK‑compliant)
@@ -364,6 +365,7 @@ export default function DebtHelpLandingPage() {
   const [formMode, setFormMode] = useState("two"); // 'single' | 'two'
   const [touched, setTouched] = useState({ fullName: false, email: false, phone: false, postcode: false });
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  const heroReview = useMemo(() => REVIEWS[Math.floor(Math.random() * REVIEWS.length)], []);
 
   const errors = useMemo(() => ({
     fullName: validateFullName(form.fullName) ? "" : "Please enter your full name",
@@ -602,6 +604,14 @@ export default function DebtHelpLandingPage() {
                 </li>
               ))}
             </ul>
+            <div className="mt-6 flex items-start gap-3">
+              <div className="flex text-amber-500">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Star key={i} className="h-4 w-4" />
+                ))}
+              </div>
+              <p className="text-sm text-slate-600 italic">“{heroReview.text}” — {heroReview.name}, {heroReview.area}</p>
+            </div>
           </motion.div>
 
           {/* Form Card */}
@@ -816,6 +826,12 @@ export default function DebtHelpLandingPage() {
               <p className="mt-2 text-sm text-slate-600">Your information is used to handle your enquiry and referral. See our <span className="hl">Privacy Notice</span> for details. You can <span className="hl">withdraw consent</span> at any time.</p>
             </div>
           </div>
+        </section>
+
+        {/* Credit utilisation calculator */}
+        <section className="mx-auto max-w-6xl px-4 pb-10">
+          <h2 className="text-2xl font-semibold text-center mb-4">Check your credit utilisation</h2>
+          <CreditCheckCalculator />
         </section>
 
         {/* Social proof — continuous marquee */}


### PR DESCRIPTION
## Summary
- add simple credit utilisation calculator component
- display testimonial snippet with star ratings near hero section
- integrate calculator section into landing page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `export REPLIT_DOMAINS=example.com && npm run lint` *(fails: Parsing error in existing `./lib` file)*
- `export REPLIT_DOMAINS=example.com && npm run build` *(fails: Parsing error in existing `./lib` file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d806e29483268e42fcf7bb33bbd3