### PR TITLE
Add organization structured data to home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -471,6 +471,18 @@ export default function DebtHelpLandingPage() {
           name="description"
           content="Keyword-rich summary of Credit Cleaners’ service"
         />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Organization",
+              name: "Credit Cleaners",
+              url: "https://creditcleaners.co.uk",
+              logo: "https://creditcleaners.co.uk/generated-icon.png",
+            }),
+          }}
+        />
       </Head>
       <style>{`
         /* ==== Conversion‑optimised palette (finance/trust) ==== */


### PR DESCRIPTION
## Summary
- embed Organization schema via JSON-LD in the home page `<Head>`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot read properties of undefined `split` in next.config.compiled.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d7ff188483268657ac533d27559c