### PR TITLE
feat: add lead api endpoint

### DIFF
--- a/pages/api/lead.ts
+++ b/pages/api/lead.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+interface LeadResponse {
+  ok: boolean
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<LeadResponse>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).end()
+  }
+
+  const lead = typeof req.body === 'string' ? JSON.parse(req.body) : req.body
+  console.log('Received lead:', lead)
+
+  return res.status(200).json({ ok: true })
+}


### PR DESCRIPTION
## Summary
- add new `POST /api/lead` endpoint that parses and logs lead data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60a0334e4832695ffaecec95cd165