### PR TITLE
chore: switch to stable next, react, and tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^15.2.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.15"
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwindcss": "^3.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.13.11",


### PR DESCRIPTION
## Summary
- use stable Next.js 14, React 18, and Tailwind CSS 3 versions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68a60a016e7c8326b0f252222f2d29bf